### PR TITLE
katherine changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,26 +23,30 @@
         <div class="container">
             <h2 id="about">About</h2>
             <div class="row">
-                <div class="col-7">
-                    <blockquote class="blockquote">"I’ve always said that the world is a different place for the heartbroken. It moves on a different 
-                        axis, at a different speed. Time skips backwards and forwards fleetingly. The heartbroken might go through thousands of 
-                        micro-emotions a day trying to figure out how to get through it without picking up the phone to hear that old familiar voice. 
-                        In the land of heartbreak, moments of strength, independence, and devil-may-care rebellion are intricately woven together 
-                        with grief, paralyzing vulnerability and hopelessness. Imagining your future might always take you on a detour back to the 
+                <div id="quotecolumn">
+                    <blockquote class="blockquote">"I’ve always said that the world is a different place for the heartbroken. It moves on a different
+                        axis, at a different speed. Time skips backwards and forwards fleetingly. The heartbroken might go through thousands of
+                        micro-emotions a day trying to figure out how to get through it without picking up the phone to hear that old familiar voice.
+                        In the land of heartbreak, moments of strength, independence, and devil-may-care rebellion are intricately woven together
+                        with grief, paralyzing vulnerability and hopelessness. Imagining your future might always take you on a detour back to the
                         past. And this is all to say, that the next album I’ll be releasing is my version of Red.
                         <br><br>
-                        Musically and lyrically, Red resembled a heartbroken person. It was all over the place, a fractured mosaic of feelings that 
-                        somehow all fit together in the end. Happy, free, confused, lonely, devastated, euphoric, wild, and tortured by memories 
-                        past. Like trying on pieces of a new life, I went into the studio and experimented with different sounds and collaborators. 
-                        And I’m not sure if it was pouring my thoughts into this album, hearing thousands of your voices sing the lyrics back to 
+                        Musically and lyrically, Red resembled a heartbroken person. It was all over the place, a fractured mosaic of feelings that
+                        somehow all fit together in the end. Happy, free, confused, lonely, devastated, euphoric, wild, and tortured by memories
+                        past. Like trying on pieces of a new life, I went into the studio and experimented with different sounds and collaborators.
+                        And I’m not sure if it was pouring my thoughts into this album, hearing thousands of your voices sing the lyrics back to
                         me in passionate solidarity, or if it was simply time, but something was healed along the way.
                         <br><br>
-                        Sometimes you need to talk it over (over and over and over) for it to ever really be... over. Like your friend who calls you 
-                        in the middle of the night going on and on about their ex, I just couldn’t stop writing. This will be the first time you hear 
+                        Sometimes you need to talk it over (over and over and over) for it to ever really be... over. Like your friend who calls you
+                        in the middle of the night going on and on about their ex, I just couldn’t stop writing. This will be the first time you hear
                         all 30 songs that were meant to go on Red. And hey, one of them is even ten minutes long."</blockquote>
                     <p class="blockquote-footer">Taylor Swift, Red (Taylor's Version) Announcement, Instagram</p>
                 </div>
-                <img src="back.png" alt="Back Cover of Red (Taylor's Version)" class="col-5">
+                <div id="imagecolumn">
+                  <img src="back.png" alt="Back Cover of Red (Taylor's Version)" id="backcover">
+                  <!-- I'd make this image's height also adjust with the screen width, because right now,
+                  when you shrink the browser size, the image compresses and looks really skinny-->
+                </div>
             </div>
             <h2 id="accolades">Accolades</h2>
             <table class="table">

--- a/style.css
+++ b/style.css
@@ -21,3 +21,12 @@ nav {
     border: 1px solid rgb(171, 57, 57);
     color:rgb(171, 57, 57)
 }
+#quotecolumn {
+  width: 60%;
+}
+#imagecolumn {
+  width: 30%;
+}
+#backcover {
+  width: 35vw; height: auto;
+}


### PR DESCRIPTION
I made the image of the back cover of Red (Taylor's Version) adjust to the screen width while staying on the right of the block quote. Instead of using col-7 or col-5, there are now just two columns, one for the quote and one for the image.